### PR TITLE
Use requirement files instead of dev extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This GitHub Action encapsulates common steps that are executed in GitHub Action 
 
 ```
 - id: common
-  uses: ghga-de/gh-action-common@v1
+  uses: ghga-de/gh-action-common@v2
 ```
 
 The action outputs the following values:

--- a/action.yaml
+++ b/action.yaml
@@ -52,4 +52,4 @@ runs:
       - name: Install Dependencies
         shell: bash
         run: |
-          pip install ".[all]"
+          pip install -r requirements.txt -r requirements-dev.txt


### PR DESCRIPTION
Use requirement-dev.txt files instead of an dev extra for installing the dev requirements.

Note: The requirements-dev.txt file should include the requirements-dev-common.txt in the first line (this is possible with pip), so this does not need to be installed explicitly here.
