### PR TITLE
Use --no-deps, use new src dir, only use dev reqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ The action outputs the following values:
 | MAIN\_SRC\_DIR | The main source directory of the microservice package |
 | CONFIG\_YAML\_ENV\_VAR\_NAME | The name of the environment variable pointing to the config yaml file |
 | CONFIG\_YAML | The config YAML file |
+
+---
+
+>Note: v3 of this action will only work with an exhaustive `requirements-dev.txt` file. If you only have top-level dependencies in that file, pip will not install the transitive dependencies. This update coincides with the move to pip-tools in the `microservice-repository-template`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This GitHub Action encapsulates common steps that are executed in GitHub Action 
 
 ```
 - id: common
-  uses: ghga-de/gh-action-common@v2
+  uses: ghga-de/gh-action-common@v3
 ```
 
 The action outputs the following values:

--- a/action.yaml
+++ b/action.yaml
@@ -49,6 +49,10 @@ runs:
         with:
           python-version: 3.9
 
+# The pip install should use --no-deps to prevent it from trying to install package dependencies:
+# The canonical set of dependencies to install for a given service should come from 
+# the lock files and the lock files only. If pip does look at package dependencies when 
+# installing a given package (like FastAPI), there is a potential for false conflicts to arise.
       - name: Install Dependencies
         shell: bash
         run: |

--- a/action.yaml
+++ b/action.yaml
@@ -36,7 +36,7 @@ runs:
         shell: bash
         run: |
           PACKAGE_NAME="$(./scripts/get_package_name.py)"
-          MAIN_SRC_DIR="${PWD}/${PACKAGE_NAME}"
+          MAIN_SRC_DIR="${PWD}/src/${PACKAGE_NAME}"
           CONFIG_YAML_ENV_VAR_NAME="$( echo ${PACKAGE_NAME^^} | sed "s/-/_/g" )_CONFIG_YAML"
           CONFIG_YAML="${PWD}/.devcontainer/.dev_config.yaml"
           # attach all other variables to the step's output:
@@ -52,4 +52,4 @@ runs:
       - name: Install Dependencies
         shell: bash
         run: |
-          pip install -r requirements.txt -r requirements-dev.txt
+          pip install --no-deps -r requirements-dev.txt


### PR DESCRIPTION
This is a change to reflect the new use of lock files in our services. The `pip install` should use `--no-deps` to prevent it from trying to install package dependencies for two reasons: 

1. The canonical set of dependencies to install for a given service should come from the lock files and the lock files only. 
2. If pip does look at package dependencies when installing a given package (like FastAPI), there is a potential for false conflicts to arise. For example, FastAPI requires Pydantic with a specification that is (according to pip) invalid when requiring hashes. The Pydantic dependency is already pinned in our lock file and pip has no need to try to resolve FastAPI's dependencies. 

Additionally, all of a service's dependencies (dev + production) should be included in the `requirements-dev.txt` lock file. The `pip install` command should therefore only reference that file. 

The MAIN_SRC_DIR value is updated to reflect the new `src` folder structure. 