### PR TITLE
Install package

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -57,3 +57,4 @@ runs:
         shell: bash
         run: |
           pip install --no-deps -r requirements-dev.txt
+          pip install --no-deps .


### PR DESCRIPTION
Updates the action to also install the package. This is needed because the new src structure causes the config check and the openapi check to fail when try to reference my_microservice (or whatever package name) unless the package is installed. Previously that was not needed. 