### PR TITLE
Allow specifying the Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,45 @@
-# GHGA GitHub Action Common
+# GHGA Microservice GitHub Action Common
 
-This GitHub Action encapsulates common steps that are executed in GitHub Action workflows within GHGA repositories. Use as follows:
+## Usage
+
+This GitHub Action encapsulates common steps that are executed in GitHub Action workflows within [GHGA repositories](https://github.com/orgs/ghga-de/repositories) for microservices and libraries. Use as follows:
 
 ```
-- id: common
-  uses: ghga-de/gh-action-common@v3
+- id: ghga-common
+  uses: ghga-de/gh-action-common@v5
+  with:
+    python-version: '3.12'
 ```
+
+If the `with` block is omitted, the default Python version for the GHGA repositories will be used, which is currently Python 3.9.
+
+## Output
 
 The action outputs the following values:
+
 | Variable | Description |
 | --- | --- |
-| PACKAGE\_NAME | Name of the microservice package |
-| MAIN\_SRC\_DIR | The main source directory of the microservice package |
-| CONFIG\_YAML\_ENV\_VAR\_NAME | The name of the environment variable pointing to the config yaml file |
-| CONFIG\_YAML | The config YAML file |
+| PACKAGE\_NAME | the name of the microservice package |
+| MAIN\_SRC\_DIR | the main source directory of the microservice package |
+| CONFIG\_YAML\_ENV\_VAR\_NAME | the name of the environment variable pointing to the config YAML file |
+| CONFIG\_YAML | the config YAML file |
 
----
+## Changelog
 
->Note: v3 of this action will only work with an exhaustive `requirements-dev.txt` file. If you only have top-level dependencies in that file, pip will not install the transitive dependencies. This update coincides with the move to pip-tools in the `microservice-repository-template`.
+### v5
+
+Allows specifying the Python version in the `with` block.
+
+### v4
+
+The lock file must now be located in the `.lock` directory.
+
+### v3
+
+This action will now only work with an exhaustive `requirements-dev.txt` file. If you only have top-level dependencies in that file, pip will not install the transitive dependencies. This update coincides with the move to pip-tools (uv) in the [microservice-repository-template](https://github.com/ghga-de/microservice-repository-template).
+
+### v2
+
+Uses a requirement file for dev requirements instead of relying on the "all" extra.
+
+

--- a/README.md
+++ b/README.md
@@ -41,5 +41,3 @@ This action will now only work with an exhaustive `requirements-dev.txt` file. I
 ### v2
 
 Uses a requirement file for dev requirements instead of relying on the "all" extra.
-
-

--- a/action.yaml
+++ b/action.yaml
@@ -25,16 +25,16 @@ inputs:
 outputs:
   PACKAGE_NAME:
     description: 'The Name of the microservice package'
-    value: ${{ steps.runtime_variables.outputs.PACKAGE_NAME }}
+    value: ${{ steps.runtime-variables.outputs.PACKAGE_NAME }}
   MAIN_SRC_DIR:
     description: 'The main src directory of the microservice package'
-    value: ${{ steps.runtime_variables.outputs.MAIN_SRC_DIR }}
+    value: ${{ steps.runtime-variables.outputs.MAIN_SRC_DIR }}
   CONFIG_YAML_ENV_VAR_NAME:
     description: 'The name of the environment variable pointing to the config YAML file'
-    value: ${{ steps.runtime_variables.outputs.CONFIG_YAML_ENV_VAR_NAME }}
+    value: ${{ steps.runtime-variables.outputs.CONFIG_YAML_ENV_VAR_NAME }}
   CONFIG_YAML:
     description: 'The config YAML file'
-    value: ${{ steps.runtime_variables.outputs.CONFIG_YAML }}
+    value: ${{ steps.runtime-variables.outputs.CONFIG_YAML }}
 
 runs:
   using: 'composite'
@@ -42,7 +42,7 @@ runs:
   steps:
 
       - name: Get and export important runtime variables
-        id: export-runtime-variables
+        id: runtime-variables
         shell: bash
         run: |
           PACKAGE_NAME="$(./scripts/get_package_name.py)"

--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2022-2024 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,24 +15,34 @@
 
 name: 'GHGA microservice common action tasks'
 description: 'Common tasks that are executed in multiple GH action workflows for GHGA microservices'
+
+inputs:
+  python-version:
+    description: 'The Python version to use'
+    required: false
+    default: '3.9'
+
 outputs:
   PACKAGE_NAME:
-    description: "Name of the microservice package"
+    description: 'The Name of the microservice package'
     value: ${{ steps.runtime_variables.outputs.PACKAGE_NAME }}
   MAIN_SRC_DIR:
-    description: "The main src directory of the microservice package"
+    description: 'The main src directory of the microservice package'
     value: ${{ steps.runtime_variables.outputs.MAIN_SRC_DIR }}
   CONFIG_YAML_ENV_VAR_NAME:
-    description: "The name of the environment variable pointing to the config yaml file"
+    description: 'The name of the environment variable pointing to the config YAML file'
     value: ${{ steps.runtime_variables.outputs.CONFIG_YAML_ENV_VAR_NAME }}
   CONFIG_YAML:
-    description: "The config YAML file"
+    description: 'The config YAML file'
     value: ${{ steps.runtime_variables.outputs.CONFIG_YAML }}
+
 runs:
-  using: "composite"
+  using: 'composite'
+
   steps:
-      - name: Get/export important runtime variables
-        id: runtime_variables
+
+      - name: Get and export important runtime variables
+        id: export-runtime-variables
         shell: bash
         run: |
           PACKAGE_NAME="$(./scripts/get_package_name.py)"
@@ -44,17 +54,22 @@ runs:
           echo "MAIN_SRC_DIR=${MAIN_SRC_DIR}" >> $GITHUB_OUTPUT
           echo "CONFIG_YAML_ENV_VAR_NAME=${CONFIG_YAML_ENV_VAR_NAME}" >> $GITHUB_OUTPUT
           echo "CONFIG_YAML=${CONFIG_YAML}" >> $GITHUB_OUTPUT
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
 
-# The pip install should use --no-deps to prevent it from trying to install package dependencies:
-# The canonical set of dependencies to install for a given service should come from 
-# the lock files and the lock files only. If pip does look at package dependencies when 
-# installing a given package (like FastAPI), there is a potential for false conflicts to arise.
+      - name: Set up Python ${{ inputs.python-version }}
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '${{ inputs.python-version }}'
+
       - name: Install Dependencies
+        id: install-dependencies
         shell: bash
+        env:
+          PIP_OPTIONS: --no-deps --disable-pip-version-check
+          # Note: We use pip with the --no-deps option to install only the dependencies
+          # that are listed in our lock files. If pip tries to install other packages,
+          # it is not guaranteed that we always get the same environment.
         run: |
-          pip install --no-deps -r ./lock/requirements-dev.txt
-          pip install --no-deps .
+          pip install $PIP_OPTIONS -r ./lock/requirements-dev.txt
+          pip install $PIP_OPTIONS .
+


### PR DESCRIPTION
This PR:

- Is intended to be tagged as the new major version v5.
- Allows selecting a Python version different from our default one. Thereby we can make use of newer Python versions in newly created services, or support dependencies that run only with certain Python versions. It also allows using a matrix strategy to test our libraries with various Python versions.
- Updates setup-python to v5.
- Removes the warning about an outdated pip version.
- Makes the README file a bit nicer and the code style more consistent.